### PR TITLE
Resolve stderr and reject actual error (not stderr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,29 @@
-# node-exec-promise
+# nexecp (node-exec-promise fork)
+
+**This is a fork from [node-exec-promise](https://www.npmjs.com/package/node-exec-promise)**.
+
+Why a fork? Two reasons:
+- the original does *not* resolve `stderr`, which I need! (`git pull` outputs both to `stdout` and `stderr`).
+- on error, it rejects `stderr` instead of the actual Error object.
+- well, wait, a 3rd reason! I could have issued a pull request, but since the interface changes, it would most likely break for everyone using a previous version.
 
 This package is a simple wrapper for `child_process.exec` and `child_process.execFile` which returns a Promise.
 
 # Installation
 
 ```bash
-npm install --save node-exec-promise
+npm install --save nexecp
 ```
 
 # Example Usage
 
 ```javascript
-var exec = require('node-exec-promise').exec;
+var exec = require('nexecp').exec;
 
-exec('ls -lah /tmp').then(function(stdout) {
-  console.log(stdout);
-}, function(stderr) {
-  console.log(stderr);
+exec('ls -lah /tmp').then(function(out) {
+  console.log(out.stdout, out.stderr);
+}, function(err) {
+  console.error(err);
 });
 ```
 
@@ -26,9 +33,10 @@ exec('ls -lah /tmp').then(function(stdout) {
 var execFile = require('node-exec-promise').execFile;
 
 gulp.task('example', function(done) {
-  execFile('ls', ['-lah', '/tmp']).then(function(stdout) {
+  execFile('ls', ['-lah', '/tmp']).then(function(out) {
+    console.log(out.stdout, out.stderr);
     done();
-  }, function(stderr) {
+  }, function(err) {
     // handle error
   });
 });

--- a/index.js
+++ b/index.js
@@ -15,20 +15,20 @@ function executeFile(file, options) {
 function doExecute(resolve, reject, command) {
   child_process.exec(command, function(error, stdout, stderr){
   	if (error) {
-      return reject(stderr);
+      return reject(error);
     }
 
-    resolve(stdout);
+    resolve({ stdout, stderr });
   });
 }
 
 function doExecuteFile(resolve, reject, file, options) {
   child_process.execFile(file, options, function(error, stdout, stderr){
   	if (error) {
-      return reject(stderr);
+      return reject(error);
     }
 
-    resolve(stdout);
+    resolve({ stdout, stderr });
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-exec-promise",
-  "version": "0.1.1",
+  "name": "nexecp",
+  "version": "0.1.3",
   "description": "Execute commands from Node.js and get a Promise back.",
   "repository": {
     "type": "git",
@@ -14,7 +14,8 @@
     "promise",
     "gulp"
   ],
-  "author": "Fabian Pirklbauer",
+  "author": "Benoît Hubert",
+  "contributors": ["Fabian Pirklbauer"],
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {},


### PR DESCRIPTION
Bring in breaking changes from a [fork](https://github.com/bhubr/node-exec-promise), requiring a major version bump.

- Resolve `stdout` and `stderr` as object: `resolve({ stdout, stderr })`
- Reject `error` object: `reject(error)`